### PR TITLE
Add ability to have a whitespace after and before curley brackets for inline expressions

### DIFF
--- a/grammars/ember-htmlbars-inline.cson
+++ b/grammars/ember-htmlbars-inline.cson
@@ -14,8 +14,8 @@
 
   'htmlbars-inline':
     'name': 'meta.tag.inline.htmlbars'
-    'begin': '(\\{\\{)(?:(if|unless|yield|else if|else)|([a-zA-Z0-9.-]+))'
-    'end': '(\\}\\})'
+    'begin': '(\\{\\{ ?)(?:(if|unless|yield|else if|else)|([a-zA-Z0-9.-]+))'
+    'end': '( ?\\}\\})'
     'captures':
       '1':
         'name': 'punctuation.definition.tag.inline.htmlbars'


### PR DESCRIPTION
Add the ability to have a white space after the opening `{{` and the closing `}}` for inline expressions, so you get the same result using `{{user.name}}` and `{{ user.name }}`
