### PR TITLE
Adds slashes and underscores to syntax

### DIFF
--- a/grammars/ember-htmlbars-core.cson
+++ b/grammars/ember-htmlbars-core.cson
@@ -25,7 +25,7 @@
 
   'htmlbars-block-open':
     'name': 'meta.tag.block.open.htmlbars'
-    'begin': '(\\{\\{)(#)(?:(if|unless|with|each|else if|else)|([a-zA-Z0-9.-]+))'
+    'begin': '(\\{\\{)(#)(?:(if|unless|with|each|else if|else)|([a-zA-Z0-9./-]+))'
     'end': '(\\}\\})'
     'captures':
       '1':

--- a/grammars/ember-htmlbars-core.cson
+++ b/grammars/ember-htmlbars-core.cson
@@ -42,7 +42,7 @@
 
   'htmlbars-block-close':
     'name': 'meta.tag.block.close.htmlbars'
-    'begin': '(\\{\\{)(/)(?:(if|unless|with|each|else if|else)|([a-zA-Z0-9.-]+))'
+    'begin': '(\\{\\{)(/)(?:(if|unless|with|each|else if|else)|([a-zA-Z0-9./-]+))'
     'end': '(\\}\\})'
     'captures':
       '1':

--- a/grammars/ember-htmlbars-inline.cson
+++ b/grammars/ember-htmlbars-inline.cson
@@ -14,7 +14,7 @@
 
   'htmlbars-inline':
     'name': 'meta.tag.inline.htmlbars'
-    'begin': '(\\{\\{)(?:(if|unless|yield|else if|else)|([a-zA-Z0-9.-]+))'
+    'begin': '(\\{\\{)(?:(if|unless|yield|else if|else)|([a-zA-Z0-9./-]+))'
     'end': '(\\}\\})'
     'captures':
       '1':

--- a/grammars/ember-htmlbars-inline.cson
+++ b/grammars/ember-htmlbars-inline.cson
@@ -14,7 +14,7 @@
 
   'htmlbars-inline':
     'name': 'meta.tag.inline.htmlbars'
-    'begin': '(\\{\\{)(?:(if|unless|yield|else if|else)|([a-zA-Z0-9./-]+))'
+    'begin': '(\\{\\{)(?:(if|unless|yield|else if|else)|([a-zA-Z0-9./_-]+))'
     'end': '(\\}\\})'
     'captures':
       '1':


### PR DESCRIPTION
Properly highlights `component/subcomponent` syntax. 

Also includes underscores to the inline definitions in case you have a property or a key on a property with an underscore. 