### PR TITLE
Package breaks default HTML comment keybinding

### DIFF
--- a/settings/language-ember-htmlbars.cson
+++ b/settings/language-ember-htmlbars.cson
@@ -1,4 +1,4 @@
-'.text.html':
+'.text.html.htmlbars':
   'editor':
     'commentStart': '{{!-- '
     'commentEnd': ' --}}'


### PR DESCRIPTION
When language-ember-htmlbars is enabled, the _"Editor: Toggle Line Comments"_ command no longer works for any file ending with `.html`. This includes files with multiple file endings (e.g. – `.html.erb`).
### Behavior

<kbd>⌘</kbd> + <kbd>/</kbd>
### Expected Outcome

```
<!--  -->
```
### Current Outcome

```
{{!--  --}}
```
### Environment
- Atom 1.0.19
- Mac OS X 10.11.1 (15B42)
